### PR TITLE
Fix: align SDK with backend develop branch API

### DIFF
--- a/api.go
+++ b/api.go
@@ -73,71 +73,27 @@ func (d *DeltaDeFi) PostOrder(data *BuildPlaceOrderTransactionRequest) (*SubmitP
 }
 
 // CancelOrder is a high-level method for canceling an existing order.
-// It handles the complete cancellation flow: building the transaction, signing it, and submitting it.
-// The operation wallet must be loaded before calling this method.
+// This method directly cancels the order without requiring transaction signing.
 //
 // Parameters:
 //   - orderId: The ID of the order to cancel
 //
 // Returns:
-//   - *SubmitCancelOrderTransactionResponse: Transaction hash of the cancellation
+//   - *CancelOrderResponse: Contains the cancelled order ID
 //   - error: nil on success, error on failure
-func (d *DeltaDeFi) CancelOrder(orderId string) (*SubmitCancelOrderTransactionResponse, error) {
-	if d.OperationWallet == nil {
-		return nil, fmt.Errorf("operation wallet is not loaded")
-	}
-
-	buildRes, err := d.Order.BuildCancelOrderTransaction(orderId)
-	if err != nil {
-		return nil, err
-	}
-
-	signedTx, err := d.OperationWallet.Signer().SignTransaction(buildRes.TxHex)
-	if err != nil {
-		return nil, err
-	}
-
-	submitRes, err := d.Order.SubmitCancelOrderTransaction(&SubmitCancelOrderTransactionRequest{
-		SignedTx: signedTx,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return submitRes, nil
+func (d *DeltaDeFi) CancelOrder(orderId string) (*CancelOrderResponse, error) {
+	return d.Order.CancelOrder(orderId)
 }
 
-// CancelAllOrders is a high-level method for canceling all existing orders.
-// It handles the complete cancellation flow: building the transaction, signing it, and submitting it.
-// The operation wallet must be loaded before calling this method.
+// CancelAllOrders is a high-level method for canceling all existing orders for a symbol.
+// This method directly cancels orders without requiring transaction signing.
+//
+// Parameters:
+//   - symbol: The trading pair symbol to cancel orders for
 //
 // Returns:
-//   - *SubmitCancelAllOrdersTransactionResponse: Details of all canceled orders
+//   - *CancelAllOrdersResponse: Contains the symbol and list of cancelled order IDs
 //   - error: nil on success, error on failure
-func (d *DeltaDeFi) CancelAllOrders() (*SubmitCancelAllOrdersTransactionResponse, error) {
-	if d.OperationWallet == nil {
-		return nil, fmt.Errorf("operation wallet is not loaded")
-	}
-
-	buildRes, err := d.Order.BuildCancelAllOrdersTransaction()
-	if err != nil {
-		return nil, err
-	}
-
-	signedTxs := make([]string, 0, len(buildRes.TxHexes))
-	for _, txHex := range buildRes.TxHexes {
-		signedTx, err := d.OperationWallet.Signer().SignTransaction(txHex)
-		if err != nil {
-			return nil, err
-		}
-		signedTxs = append(signedTxs, signedTx)
-	}
-
-	submitRes, err := d.Order.SubmitCancelAllOrdersTransaction(&SubmitCancelAllOrdersTransactionRequest{
-		SignedTxs: signedTxs,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-	return submitRes, nil
+func (d *DeltaDeFi) CancelAllOrders(symbol string) (*CancelAllOrdersResponse, error) {
+	return d.Order.CancelAllOrders(symbol)
 }

--- a/api_accounts.go
+++ b/api_accounts.go
@@ -315,3 +315,301 @@ func (c *AccountsClient) SubmitTransferalTransaction(data *SubmitTransferalTrans
 	}
 	return &submitTransferalTransactionResponse, nil
 }
+
+// GetOpenOrders retrieves open orders for a specific symbol with pagination.
+//
+// Parameters:
+//   - data: Request parameters including symbol, limit, and page
+//
+// Returns:
+//   - *GetOpenOrdersResponse: Paginated open orders
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetOpenOrders(data *GetOpenOrdersRequest) (*GetOpenOrdersResponse, error) {
+	params := make(map[string]string)
+	params["symbol"] = data.Symbol
+
+	if data.Limit > 0 {
+		params["limit"] = strconv.Itoa(data.Limit)
+	}
+	if data.Page > 0 {
+		params["page"] = strconv.Itoa(data.Page)
+	}
+
+	bodyBytes, err := c.client.getWithParams(c.pathUrl+"/open-orders", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetOpenOrdersResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetTradeOrders retrieves trade orders (order history) for a specific symbol with pagination.
+//
+// Parameters:
+//   - data: Request parameters including symbol, limit, and page
+//
+// Returns:
+//   - *GetTradeOrdersResponse: Paginated trade orders
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetTradeOrders(data *GetTradeOrdersRequest) (*GetTradeOrdersResponse, error) {
+	params := make(map[string]string)
+	params["symbol"] = data.Symbol
+
+	if data.Limit > 0 {
+		params["limit"] = strconv.Itoa(data.Limit)
+	}
+	if data.Page > 0 {
+		params["page"] = strconv.Itoa(data.Page)
+	}
+
+	bodyBytes, err := c.client.getWithParams(c.pathUrl+"/trade-orders", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTradeOrdersResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetAccountTrades retrieves account trades (fills) for a specific symbol with pagination.
+//
+// Parameters:
+//   - data: Request parameters including symbol, limit, and page
+//
+// Returns:
+//   - *GetAccountTradesResponse: Paginated account trades
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetAccountTrades(data *GetAccountTradesRequest) (*GetAccountTradesResponse, error) {
+	params := make(map[string]string)
+	params["symbol"] = data.Symbol
+
+	if data.Limit > 0 {
+		params["limit"] = strconv.Itoa(data.Limit)
+	}
+	if data.Page > 0 {
+		params["page"] = strconv.Itoa(data.Page)
+	}
+
+	bodyBytes, err := c.client.getWithParams(c.pathUrl+"/trades", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAccountTradesResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetMaxDeposit retrieves the maximum deposit amount allowed.
+//
+// Returns:
+//   - *GetMaxDepositResponse: Maximum deposit amount
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetMaxDeposit() (*GetMaxDepositResponse, error) {
+	bodyBytes, err := c.client.get(c.pathUrl + "/max-deposit")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetMaxDepositResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetTransferalRecords retrieves transferal records with optional filtering and pagination.
+//
+// Parameters:
+//   - data: Request parameters including limit, page, and status filter
+//
+// Returns:
+//   - *GetTransferalRecordsResponse: Array of transferal records
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetTransferalRecords(data *GetTransferalRecordsRequest) (*GetTransferalRecordsResponse, error) {
+	params := make(map[string]string)
+
+	if data.Limit > 0 {
+		params["limit"] = strconv.Itoa(data.Limit)
+	}
+	if data.Page > 0 {
+		params["page"] = strconv.Itoa(data.Page)
+	}
+	if data.Status != "" {
+		params["status"] = data.Status
+	}
+
+	bodyBytes, err := c.client.getWithParams(c.pathUrl+"/transferal-records", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetTransferalRecordsResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetTransferalRecordByTxHash retrieves a specific transferal record by transaction hash.
+//
+// Parameters:
+//   - txHash: The transaction hash of the transferal record
+//
+// Returns:
+//   - *TransferalRecord: The transferal record
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetTransferalRecordByTxHash(txHash string) (*TransferalRecord, error) {
+	bodyBytes, err := c.client.get(c.pathUrl + "/transferal-records/" + txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var response TransferalRecord
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// BuildRequestTransferalTransaction builds a request transferal transaction.
+// This is used when requesting a transfer from another address.
+//
+// Parameters:
+//   - data: Request parameters including transferal amount, from address, and type
+//
+// Returns:
+//   - *BuildRequestTransferalTransactionResponse: Transaction hex ready for signing
+//   - error: nil on success, error on failure
+func (c *AccountsClient) BuildRequestTransferalTransaction(data *BuildRequestTransferalTransactionRequest) (*BuildRequestTransferalTransactionResponse, error) {
+	bodyBytes, err := c.client.post(c.pathUrl+"/request-transferal/build", data)
+	if err != nil {
+		return nil, err
+	}
+
+	var response BuildRequestTransferalTransactionResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// SubmitRequestTransferalTransaction submits a signed request transferal transaction.
+//
+// Parameters:
+//   - data: Submit request containing the signed transaction hex
+//
+// Returns:
+//   - *SubmitRequestTransferalTransactionResponse: Transaction hash of the submitted transaction
+//   - error: nil on success, error on failure
+func (c *AccountsClient) SubmitRequestTransferalTransaction(data *SubmitRequestTransferalTransactionRequest) (*SubmitRequestTransferalTransactionResponse, error) {
+	bodyBytes, err := c.client.post(c.pathUrl+"/request-transferal/submit", data)
+	if err != nil {
+		return nil, err
+	}
+
+	var response SubmitRequestTransferalTransactionResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetAPIKey retrieves the existing API key for the authenticated account.
+//
+// Returns:
+//   - *GetAPIKeyResponse: API key and creation timestamp
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetAPIKey() (*GetAPIKeyResponse, error) {
+	bodyBytes, err := c.client.get(c.pathUrl + "/api-key")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetAPIKeyResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetSpotAccount retrieves the spot account details for the authenticated user.
+//
+// Returns:
+//   - *GetSpotAccountResponse: Spot account details
+//   - error: nil on success, error on failure
+func (c *AccountsClient) GetSpotAccount() (*GetSpotAccountResponse, error) {
+	bodyBytes, err := c.client.get(c.pathUrl + "/spot-account")
+	if err != nil {
+		return nil, err
+	}
+
+	var response GetSpotAccountResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// CreateSpotAccount creates a new spot account.
+//
+// Parameters:
+//   - data: Request containing user ID, encrypted operation key, and key hash
+//
+// Returns:
+//   - *CreateSpotAccountResponse: Created spot account details
+//   - error: nil on success, error on failure
+func (c *AccountsClient) CreateSpotAccount(data *CreateSpotAccountRequest) (*CreateSpotAccountResponse, error) {
+	bodyBytes, err := c.client.post(c.pathUrl+"/spot-account", data)
+	if err != nil {
+		return nil, err
+	}
+
+	var response CreateSpotAccountResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// UpdateSpotAccount updates an existing spot account.
+//
+// Parameters:
+//   - data: Request containing user ID and new encrypted operation key
+//
+// Returns:
+//   - *UpdateSpotAccountResponse: Updated spot account details
+//   - error: nil on success, error on failure
+func (c *AccountsClient) UpdateSpotAccount(data *UpdateSpotAccountRequest) (*UpdateSpotAccountResponse, error) {
+	bodyBytes, err := c.client.patch(c.pathUrl+"/spot-account", data)
+	if err != nil {
+		return nil, err
+	}
+
+	var response UpdateSpotAccountResponse
+	err = json.Unmarshal(bodyBytes, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/api_client.go
+++ b/api_client.go
@@ -225,3 +225,32 @@ func (c *Client) delete(url string, body interface{}) ([]byte, error) {
 
 	return bodyBytes, nil
 }
+
+// patch performs a PATCH request with JSON body.
+// It automatically adds authentication headers and marshals the request body.
+func (c *Client) patch(url string, body interface{}) ([]byte, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("PATCH", c.BaseURL+url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("X-API-KEY", c.ApiKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bodyBytes, nil
+}

--- a/api_order.go
+++ b/api_order.go
@@ -42,47 +42,50 @@ func (c *OrderClient) BuildPlaceOrderTransaction(data *BuildPlaceOrderTransactio
 	return &buildPlaceOrderTransactionResponse, nil
 }
 
-// BuildCancelOrderTransaction builds a transaction for canceling an existing order.
-// The returned transaction hex must be signed and then submitted using SubmitCancelOrderTransactionRequest.
+// CancelOrder cancels an existing order by order ID.
+// This is a simplified endpoint that handles cancellation directly without build/sign/submit flow.
 //
 // Parameters:
 //   - orderId: The unique identifier of the order to cancel
 //
 // Returns:
-//   - *BuildCancelOrderTransactionResponse: Transaction hex ready for signing
+//   - *CancelOrderResponse: Contains the cancelled order ID
 //   - error: nil on success, error on failure
-func (c *OrderClient) BuildCancelOrderTransaction(orderId string) (*BuildCancelOrderTransactionResponse, error) {
-	bodyBytes, err := c.client.delete(c.pathUrl+"/"+orderId+"/build", nil)
+func (c *OrderClient) CancelOrder(orderId string) (*CancelOrderResponse, error) {
+	bodyBytes, err := c.client.post(c.pathUrl+"/"+orderId+"/cancel", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var buildCancelOrderTransactionResponse BuildCancelOrderTransactionResponse
-	err = json.Unmarshal(bodyBytes, &buildCancelOrderTransactionResponse)
+	var cancelOrderResponse CancelOrderResponse
+	err = json.Unmarshal(bodyBytes, &cancelOrderResponse)
 	if err != nil {
 		return nil, err
 	}
-	return &buildCancelOrderTransactionResponse, nil
+	return &cancelOrderResponse, nil
 }
 
-// BuildCancelAllOrdersTransaction builds a transaction for canceling all existing orders.
-// The returned transaction hex must be signed and then submitted using SubmitCancelAllOrdersTransactionRequest.
+// CancelAllOrders cancels all open orders for a given symbol.
+// This is a simplified endpoint that handles cancellation directly without build/sign/submit flow.
+//
+// Parameters:
+//   - symbol: The trading pair symbol to cancel orders for
 //
 // Returns:
-//   - *BuildCancelAllOrdersTransactionResponse: Transaction hex ready for signing
+//   - *CancelAllOrdersResponse: Contains the symbol and list of cancelled order IDs
 //   - error: nil on success, error on failure
-func (c *OrderClient) BuildCancelAllOrdersTransaction() (*BuildCancelAllOrdersTransactionResponse, error) {
-	bodyBytes, err := c.client.delete(c.pathUrl+"/cancel-all/build", nil)
+func (c *OrderClient) CancelAllOrders(symbol string) (*CancelAllOrdersResponse, error) {
+	bodyBytes, err := c.client.post(c.pathUrl+"/cancel-all", &CancelAllOrdersRequest{Symbol: symbol})
 	if err != nil {
 		return nil, err
 	}
 
-	var buildCancelAllOrdersTransactionResponse BuildCancelAllOrdersTransactionResponse
-	err = json.Unmarshal(bodyBytes, &buildCancelAllOrdersTransactionResponse)
+	var cancelAllOrdersResponse CancelAllOrdersResponse
+	err = json.Unmarshal(bodyBytes, &cancelAllOrdersResponse)
 	if err != nil {
 		return nil, err
 	}
-	return &buildCancelAllOrdersTransactionResponse, nil
+	return &cancelAllOrdersResponse, nil
 }
 
 // SubmitPlaceOrderTransaction submits a signed place order transaction to the network.
@@ -107,46 +110,3 @@ func (c *OrderClient) SubmitPlaceOrderTransaction(data *SubmitPlaceOrderTransact
 	return &submitPlaceOrderTransactionResponse, nil
 }
 
-// SubmitCancelOrderTransaction submits a signed cancel order transaction to the network.
-//
-// Parameters:
-//   - data: Submit request containing the signed transaction hex
-//
-// Returns:
-//   - *SubmitCancelOrderTransactionResponse: Transaction hash of the cancellation
-//   - error: nil on success, error on failure
-func (c *OrderClient) SubmitCancelOrderTransaction(data *SubmitCancelOrderTransactionRequest) (*SubmitCancelOrderTransactionResponse, error) {
-	bodyBytes, err := c.client.delete(c.pathUrl+"/submit", data)
-	if err != nil {
-		return nil, err
-	}
-
-	var submitCancelOrderTransactionResponse SubmitCancelOrderTransactionResponse
-	err = json.Unmarshal(bodyBytes, &submitCancelOrderTransactionResponse)
-	if err != nil {
-		return nil, err
-	}
-	return &submitCancelOrderTransactionResponse, nil
-}
-
-// SubmitCancelAllOrdersTransaction submits a signed cancel all orders transaction to the network.
-//
-// Parameters:
-//   - data: Submit request containing the signed transaction hex
-//
-// Returns:
-//   - *SubmitCancelAllOrdersTransactionResponse: Transaction hash of the cancellation
-//   - error: nil on success, error on failure
-func (c *OrderClient) SubmitCancelAllOrdersTransaction(data *SubmitCancelAllOrdersTransactionRequest) (*SubmitCancelAllOrdersTransactionResponse, error) {
-	bodyBytes, err := c.client.delete(c.pathUrl+"/cancel-all/submit", data)
-	if err != nil {
-		return nil, err
-	}
-
-	var submitCancelAllOrdersTransactionResponse SubmitCancelAllOrdersTransactionResponse
-	err = json.Unmarshal(bodyBytes, &submitCancelAllOrdersTransactionResponse)
-	if err != nil {
-		return nil, err
-	}
-	return &submitCancelAllOrdersTransactionResponse, nil
-}

--- a/models.go
+++ b/models.go
@@ -4,12 +4,14 @@ package deltadefi
 type OrderStatus string
 
 const (
-	OrderStatusBuilding   OrderStatus = "building"
-	OrderStatusProcessing OrderStatus = "processing"
-	OrderStatusOpen       OrderStatus = "open"
-	OrderStatusClosed     OrderStatus = "closed"
-	OrderStatusFailed     OrderStatus = "failed"
-	OrderStatusCancelled  OrderStatus = "cancelled"
+	OrderStatusProcessing          OrderStatus = "processing"
+	OrderStatusOpen                OrderStatus = "open"
+	OrderStatusFullyFilled         OrderStatus = "fully_filled"
+	OrderStatusPartiallyFilled     OrderStatus = "partially_filled"
+	OrderStatusCancelled           OrderStatus = "cancelled"
+	OrderStatusPartiallyCancelled  OrderStatus = "partially_cancelled"
+	OrderStatusFailed              OrderStatus = "failed"
+	OrderStatusClosed              OrderStatus = "closed"
 )
 
 // OrderSide represents whether an order is buying or selling.
@@ -32,7 +34,11 @@ const (
 type Symbol string
 
 const (
-	ADAUSDM Symbol = "ADAUSDM"
+	ADAUSDM    Symbol = "ADAUSDM"
+	HOSKYUSDM  Symbol = "HOSKYUSDM"
+	NIGHTUSDM  Symbol = "NIGHTUSDM"
+	IAGUSDM    Symbol = "IAGUSDM"
+	SNEKUSDM   Symbol = "SNEKUSDM"
 )
 
 // OrderJSON represents a complete order with all its details.

--- a/requests.go
+++ b/requests.go
@@ -36,8 +36,9 @@ type BuildWithdrawalTransactionRequest struct {
 
 // BuildTransferalTransactionRequest contains parameters for building a transfer transaction.
 type BuildTransferalTransactionRequest struct {
-	TransferalAmount []rum.Asset `json:"transferal_amount"`
-	ToAddress        string      `json:"to_address"`
+	TransferalAmount []rum.Asset    `json:"transferal_amount"`
+	ToAddress        string         `json:"to_address"`
+	TransferalType   TransferalType `json:"transferal_type,omitempty"`
 }
 
 // SubmitDepositTransactionRequest contains the signed transaction for deposit submission.
@@ -169,6 +170,7 @@ type CreateSpotAccountRequest struct {
 	EncryptedOperationKey string `json:"encrypted_operation_key"`
 	OperationKeyHash      string `json:"operation_key_hash"`
 	IsScriptOperationKey  *bool  `json:"is_script_operation_key"`
+	ReferralCode          string `json:"referral_code,omitempty"`
 }
 
 // UpdateSpotAccountRequest contains parameters for updating a spot account.

--- a/requests.go
+++ b/requests.go
@@ -75,14 +75,15 @@ type GetAggregatedPriceRequest struct {
 }
 
 // BuildPlaceOrderTransactionRequest contains parameters for building an order placement transaction.
+// Note: Either QuoteQuantity or BaseQuantity must be provided, but not both.
 type BuildPlaceOrderTransactionRequest struct {
 	Symbol                Symbol    `json:"symbol"`
 	Side                  OrderSide `json:"side"`
 	Type                  OrderType `json:"type"`
-	Quantity              float64   `json:"quantity"`
-	Price                 *float64  `json:"price,omitempty"`
-	MaxSlippageBasisPoint *int      `json:"max_slippage_basis_point,omitempty"`
-	LimitSlippage         *bool     `json:"limit_slippage,omitempty"`
+	QuoteQuantity         string    `json:"quote_quantity,omitempty"`
+	BaseQuantity          string    `json:"base_quantity,omitempty"`
+	Price                 string    `json:"price,omitempty"`
+	MaxSlippageBasisPoint *string   `json:"max_slippage_basis_point,omitempty"`
 	PostOnly              bool      `json:"post_only,omitempty"`
 }
 
@@ -92,14 +93,88 @@ type SubmitPlaceOrderTransactionRequest struct {
 	SignedTx string `json:"signed_tx"`
 }
 
-// SubmitCancelOrderTransactionRequest contains the signed transaction for order cancellation.
-type SubmitCancelOrderTransactionRequest struct {
+// CancelAllOrdersRequest contains parameters for canceling all orders for a symbol.
+type CancelAllOrdersRequest struct {
+	Symbol string `json:"symbol"`
+}
+
+// GetOpenOrdersRequest contains parameters for querying open orders.
+type GetOpenOrdersRequest struct {
+	Symbol string `json:"symbol"`
+	Limit  int    `json:"limit,omitempty"`
+	Page   int    `json:"page,omitempty"`
+}
+
+// GetTradeOrdersRequest contains parameters for querying trade orders.
+type GetTradeOrdersRequest struct {
+	Symbol string `json:"symbol"`
+	Limit  int    `json:"limit,omitempty"`
+	Page   int    `json:"page,omitempty"`
+}
+
+// GetAccountTradesRequest contains parameters for querying account trades.
+type GetAccountTradesRequest struct {
+	Symbol string `json:"symbol"`
+	Limit  int    `json:"limit,omitempty"`
+	Page   int    `json:"page,omitempty"`
+}
+
+// GetTransferalRecordsRequest contains parameters for querying transferal records.
+type GetTransferalRecordsRequest struct {
+	Limit  int    `json:"limit,omitempty"`
+	Page   int    `json:"page,omitempty"`
+	Status string `json:"status,omitempty"` // "pending" or "confirmed"
+}
+
+// GetDepositRecordsRequest contains parameters for querying deposit records.
+type GetDepositRecordsRequest struct {
+	Limit int `json:"limit,omitempty"`
+	Page  int `json:"page,omitempty"`
+}
+
+// GetWithdrawalRecordsRequest contains parameters for querying withdrawal records.
+type GetWithdrawalRecordsRequest struct {
+	Limit int `json:"limit,omitempty"`
+	Page  int `json:"page,omitempty"`
+}
+
+// GetAccountBalanceRequest contains parameters for querying account balance.
+type GetAccountBalanceRequest struct {
+	AssetUnit string `json:"asset_unit,omitempty"`
+}
+
+// TransferalType represents the type of transferal transaction.
+type TransferalType string
+
+const (
+	TransferalTypeDeposit    TransferalType = "deposit"
+	TransferalTypeWithdrawal TransferalType = "withdrawal"
+)
+
+// BuildRequestTransferalTransactionRequest contains parameters for building a request transferal transaction.
+type BuildRequestTransferalTransactionRequest struct {
+	TransferalAmount []rum.Asset    `json:"transferal_amount"`
+	FromAddress      string         `json:"from_address"`
+	TransferalType   TransferalType `json:"transferal_type"`
+}
+
+// SubmitRequestTransferalTransactionRequest contains the signed transaction for request transferal submission.
+type SubmitRequestTransferalTransactionRequest struct {
 	SignedTx string `json:"signed_tx"`
 }
 
-// SubmitCancelAllOrdersTransactionRequest contains the signed transaction for order cancellation.
-type SubmitCancelAllOrdersTransactionRequest struct {
-	SignedTxs []string `json:"signed_txs"`
+// CreateSpotAccountRequest contains parameters for creating a spot account.
+type CreateSpotAccountRequest struct {
+	UserId                string `json:"user_id"`
+	EncryptedOperationKey string `json:"encrypted_operation_key"`
+	OperationKeyHash      string `json:"operation_key_hash"`
+	IsScriptOperationKey  *bool  `json:"is_script_operation_key"`
+}
+
+// UpdateSpotAccountRequest contains parameters for updating a spot account.
+type UpdateSpotAccountRequest struct {
+	UserId                string `json:"user_id"`
+	EncryptedOperationKey string `json:"encrypted_operation_key"`
 }
 
 // FloatPtr returns a pointer to the given float64 value.
@@ -118,4 +193,10 @@ func BoolPtr(b bool) *bool {
 // Useful for setting optional fields in request structures.
 func IntPtr(i int) *int {
 	return &i
+}
+
+// StringPtr returns a pointer to the given string value.
+// Useful for setting optional fields in request structures.
+func StringPtr(s string) *string {
+	return &s
 }

--- a/responses.go
+++ b/responses.go
@@ -63,9 +63,10 @@ type GetWithdrawalRecordsResponse []WithdrawalRecord
 
 // AssetBalance represents the balance of a specific asset showing free and locked amounts.
 type AssetBalance struct {
-	Asset  string  `json:"asset"`
-	Free   float64 `json:"free"`
-	Locked float64 `json:"locked"`
+	Asset     string  `json:"asset"`
+	AssetUnit string  `json:"asset_unit"`
+	Free      float64 `json:"free"`
+	Locked    float64 `json:"locked"`
 }
 
 // GetAccountBalanceResponse is a collection of asset balances for the account.
@@ -73,7 +74,8 @@ type GetAccountBalanceResponse []AssetBalance
 
 // CreateNewAPIKeyResponse contains a newly generated API key.
 type CreateNewAPIKeyResponse struct {
-	APIKey string `json:"api_key"`
+	APIKey    string `json:"api_key"`
+	CreatedAt string `json:"created_at"`
 }
 
 // BuildDepositTransactionResponse contains the transaction hex for deposit operations.
@@ -134,7 +136,7 @@ type Trade struct {
 
 // Candlestick represents OHLCV (Open, High, Low, Close, Volume) data for a specific time period.
 type Candlestick struct {
-	Timestamp int64   `json:"t"`
+	Timestamp int32   `json:"t"`
 	Symbol    string  `json:"s"`
 	Open      float64 `json:"o"`
 	High      float64 `json:"h"`
@@ -153,9 +155,8 @@ type BuildPlaceOrderTransactionResponse struct {
 }
 
 // SubmitPlaceOrderTransactionResponse contains the order details after successful submission.
-type SubmitPlaceOrderTransactionResponse struct {
-	Order OrderJSON `json:"order"`
-}
+// The API returns OrderResponse directly without wrapping.
+type SubmitPlaceOrderTransactionResponse = OrderResponse
 
 // CancelOrderResponse contains the order ID of the cancelled order.
 type CancelOrderResponse struct {
@@ -207,15 +208,30 @@ type UpdateSpotAccountResponse struct {
 	UpdatedAt             string `json:"updated_at"`
 }
 
+// TransferStatus represents the status of a transfer.
+type TransferStatus string
+
+const (
+	TransferStatusPending   TransferStatus = "pending"
+	TransferStatusConfirmed TransferStatus = "confirmed"
+)
+
+// TransferDirection represents the direction of a transfer.
+type TransferDirection string
+
+const (
+	TransferDirectionIncoming TransferDirection = "incoming"
+	TransferDirectionOutgoing TransferDirection = "outgoing"
+)
+
 // TransferalRecord represents a single transferal transaction record.
 type TransferalRecord struct {
 	CreatedAt      string            `json:"created_at"`
-	Status         TransactionStatus `json:"status"`
+	Status         TransferStatus    `json:"status"`
 	Assets         []Asset           `json:"assets"`
+	TransferalType TransferalType    `json:"transferal_type"`
 	TxHash         string            `json:"tx_hash"`
-	ToAddress      string            `json:"to_address,omitempty"`
-	FromAddress    string            `json:"from_address,omitempty"`
-	TransferalType string            `json:"transferal_type,omitempty"`
+	Direction      TransferDirection `json:"direction"`
 }
 
 // GetTransferalRecordsResponse is a collection of transferal transaction records.

--- a/responses.go
+++ b/responses.go
@@ -152,27 +152,150 @@ type BuildPlaceOrderTransactionResponse struct {
 	TxHex   string `json:"tx_hex"`
 }
 
-// BuildCancelOrderTransactionResponse contains the transaction hex for order cancellation.
-type BuildCancelOrderTransactionResponse struct {
-	TxHex string `json:"tx_hex"`
-}
-
-// BuildCancelAllOrdersTransactionResponse contains the transaction hex for order cancellation.
-type BuildCancelAllOrdersTransactionResponse struct {
-	TxHexes []string `json:"tx_hexes"`
-}
-
 // SubmitPlaceOrderTransactionResponse contains the order details after successful submission.
 type SubmitPlaceOrderTransactionResponse struct {
 	Order OrderJSON `json:"order"`
 }
 
-// SubmitCancelOrderTransactionResponse contains the transaction hash after order cancellation.
-type SubmitCancelOrderTransactionResponse struct {
-	TxHash string `json:"txhash"`
+// CancelOrderResponse contains the order ID of the cancelled order.
+type CancelOrderResponse struct {
+	OrderId string `json:"order_id"`
 }
 
-// SubmitCancelAllOrdersTransactionResponse contains the transaction hash after order cancellation.
-type SubmitCancelAllOrdersTransactionResponse struct {
-	CancelledOrderIds []string `json:"cancelled_order_ids"`
+// CancelAllOrdersResponse contains details of all cancelled orders.
+type CancelAllOrdersResponse struct {
+	Symbol   string   `json:"symbol"`
+	OrderIds []string `json:"order_ids"`
+}
+
+// GetMaxDepositResponse contains the maximum deposit amount.
+type GetMaxDepositResponse struct {
+	MaxDeposit string `json:"max_deposit"`
+}
+
+// GetAPIKeyResponse contains the API key and creation timestamp.
+type GetAPIKeyResponse struct {
+	ApiKey    string `json:"api_key"`
+	CreatedAt string `json:"created_at"`
+}
+
+// GetSpotAccountResponse contains spot account details.
+type GetSpotAccountResponse struct {
+	AccountID             string `json:"account_id"`
+	AccountType           string `json:"account_type"`
+	EncryptedOperationKey string `json:"encrypted_operation_key"`
+	OperationKeyHash      string `json:"operation_key_hash"`
+	CreatedAt             string `json:"created_at"`
+}
+
+// CreateSpotAccountResponse contains the created spot account details.
+type CreateSpotAccountResponse struct {
+	AccountID             string `json:"account_id"`
+	AccountType           string `json:"account_type"`
+	EncryptedOperationKey string `json:"encrypted_operation_key"`
+	OperationKeyHash      string `json:"operation_key_hash"`
+	CreatedAt             string `json:"created_at"`
+}
+
+// UpdateSpotAccountResponse contains the updated spot account details.
+type UpdateSpotAccountResponse struct {
+	AccountID             string `json:"account_id"`
+	AccountType           string `json:"account_type"`
+	EncryptedOperationKey string `json:"encrypted_operation_key"`
+	OperationKeyHash      string `json:"operation_key_hash"`
+	CreatedAt             string `json:"created_at"`
+	UpdatedAt             string `json:"updated_at"`
+}
+
+// TransferalRecord represents a single transferal transaction record.
+type TransferalRecord struct {
+	CreatedAt      string            `json:"created_at"`
+	Status         TransactionStatus `json:"status"`
+	Assets         []Asset           `json:"assets"`
+	TxHash         string            `json:"tx_hash"`
+	ToAddress      string            `json:"to_address,omitempty"`
+	FromAddress    string            `json:"from_address,omitempty"`
+	TransferalType string            `json:"transferal_type,omitempty"`
+}
+
+// GetTransferalRecordsResponse is a collection of transferal transaction records.
+type GetTransferalRecordsResponse []TransferalRecord
+
+// GetTransferalRecordByTxHashResponse contains a single transferal record.
+type GetTransferalRecordByTxHashResponse struct {
+	TransferalRecord TransferalRecord `json:"transferal_record"`
+}
+
+// BuildRequestTransferalTransactionResponse contains the transaction hex for request transferal.
+type BuildRequestTransferalTransactionResponse struct {
+	TxHex string `json:"tx_hex"`
+}
+
+// SubmitRequestTransferalTransactionResponse contains the transaction hash after request transferal submission.
+type SubmitRequestTransferalTransactionResponse struct {
+	TxHash string `json:"tx_hash"`
+}
+
+// OrderResponse represents an order with quantities in human-readable format (from Espresso develop).
+type OrderResponse struct {
+	ID                    string                         `json:"id"`
+	AccountID             string                         `json:"account_id"`
+	ActiveOrderUtxoID     *string                        `json:"active_order_utxo_id,omitempty"`
+	Status                string                         `json:"status"`
+	Symbol                Symbol                         `json:"symbol"`
+	BaseQty               string                         `json:"base_qty"`
+	QuoteQty              string                         `json:"quote_qty"`
+	Side                  OrderSide                      `json:"side"`
+	Price                 string                         `json:"price"`
+	Type                  OrderType                      `json:"type"`
+	SlippageBp            *uint64                        `json:"slippage_bp,omitempty"`
+	MarketOrderLimitPrice *string                        `json:"market_order_limit_price,omitempty"`
+	LockedBaseQty         string                         `json:"locked_base_qty"`
+	LockedQuoteQty        string                         `json:"locked_quote_qty"`
+	ExecutedBaseQty       string                         `json:"executed_base_qty"`
+	ExecutedQuoteQty      string                         `json:"executed_quote_qty"`
+	ObOpenOrderBaseQty    string                         `json:"ob_open_order_base_qty"`
+	CommissionUnit        string                         `json:"commission_unit"`
+	Commission            string                         `json:"commission"`
+	CommissionRateBp      uint64                         `json:"commission_rate_bp"`
+	ExecutedPrice         string                         `json:"executed_price"`
+	CreatedAt             string                         `json:"created_at"`
+	UpdatedAt             string                         `json:"updated_at"`
+	OrderExecutionRecords []OrderExecutionRecordResponse `json:"order_execution_records,omitempty"`
+}
+
+// OrderExecutionRecordResponse represents a trade execution with quantities in human-readable format.
+type OrderExecutionRecordResponse struct {
+	ID                  string `json:"id"`
+	OrderID             string `json:"order_id"`
+	AccountID           string `json:"account_id"`
+	ExecutionPrice      string `json:"execution_price"`
+	FilledBaseQty       string `json:"filled_base_qty"`
+	FilledQuoteQty      string `json:"filled_quote_qty"`
+	CommissionUnit      string `json:"commission_unit"`
+	Commission          string `json:"commission"`
+	Role                string `json:"role"`
+	CounterPartyOrderID string `json:"counter_party_order_id"`
+	CreatedAt           string `json:"created_at"`
+}
+
+// GetOpenOrdersResponse contains paginated open orders.
+type GetOpenOrdersResponse struct {
+	Data       []OrderResponse `json:"data"`
+	TotalCount int             `json:"total_count"`
+	TotalPage  int             `json:"total_page"`
+}
+
+// GetTradeOrdersResponse contains paginated trade orders.
+type GetTradeOrdersResponse struct {
+	Data       []OrderResponse `json:"data"`
+	TotalCount int             `json:"total_count"`
+	TotalPage  int             `json:"total_page"`
+}
+
+// GetAccountTradesResponse contains paginated account trades.
+type GetAccountTradesResponse struct {
+	Data       []OrderExecutionRecordResponse `json:"data"`
+	TotalCount int                            `json:"total_count"`
+	TotalPage  int                            `json:"total_page"`
 }


### PR DESCRIPTION
BREAKING CHANGES:
   - CancelOrder/CancelAllOrders no longer use build/sign/submit pattern
   - CancelAllOrders now requires symbol parameter
   - BuildPlaceOrderTransactionRequest.Quantity replaced with QuoteQuantity/BaseQuantity
   - Numeric fields changed to string types (Price, MaxSlippageBasisPoint)

   New endpoints added:
   - GetOpenOrders, GetTradeOrders, GetAccountTrades
   - GetMaxDeposit, GetTransferalRecords, GetTransferalRecordByTxHash
   - BuildRequestTransferalTransaction, SubmitRequestTransferalTransaction
   - GetAPIKey, GetSpotAccount, CreateSpotAccount, UpdateSpotAccount

   Other changes:
   - Added PATCH HTTP method support
   - Added StringPtr helper function
   - Added TransferalType enum